### PR TITLE
에디터에서 CSS 프로퍼티 값으로 공백을 입력할 수 없던 버그 수정

### DIFF
--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -428,7 +428,9 @@
     }
 
     _codeInputEventListener({ currentTarget, currentTarget: { value } }) {
-      currentTarget.value = currentTarget.value.trim();
+      if (currentTarget.value.trim() === '') {
+        currentTarget.value = '';
+      }
       currentTarget.style.width =
         (value.length > 4 ? (value.length + 1) * 9 : 50) + 'px';
     }


### PR DESCRIPTION
- 에디터에서 CSS 프로퍼티 값으로 공백을 입력할 수 없던 버그 수정