### PR TITLE
특정 상황에서 드롭다운이 나오지 않는 버그 수정

### DIFF
--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -594,6 +594,11 @@
           if (this._isDropdownOpen) {
             this._dropdownParent.removeChild(this._dropdown);
             this._isDropdownOpen = false;
+
+            if (this._dropdownParent === targetCode) {
+              this._dropdownParent = null;
+              return;
+            }
           }
 
           if (!targetCode.classList.contains('button-code')) {
@@ -601,11 +606,6 @@
           }
 
           if (targetCode.tagName === 'INPUT') {
-            return;
-          }
-
-          if (this._dropdownParent === targetCode) {
-            this._dropdownParent = null;
             return;
           }
 


### PR DESCRIPTION
- CSS 속성 버튼을 눌러 드롭다운이 나온 상태에서 빈 공간을 눌러 드롭다운을 닫고, 다시 동일한 CSS 속성 버튼을 눌렀을 때 첫 클릭에 드롭다운이 나오지 않고 두 번째 클릭부터 드롭다운이 나오는 버그 수정