### PR TITLE
에디터 버그 수정 및 UI 개선

### DIFF
--- a/utils/editor/editor.css
+++ b/utils/editor/editor.css
@@ -185,6 +185,10 @@
   color: var(--gray-6);
 }
 
+.fg-editor.snippet-mode .code {
+  user-select: none;
+}
+
 .fg-editor.free-mode .code {
   padding: 0;
 }

--- a/utils/editor/editor.css
+++ b/utils/editor/editor.css
@@ -1,15 +1,16 @@
 .fg-editor {
   --pc-height-content: 300px;
   --pc-height-header: 68px;
+  --pc-min-height: 180px;
   --pc-item: 70px;
 
   --mobile-height-content: 140px;
   --mobile-height-header: 55px;
+  --mobile-min-height: 100px;
   --mobile-item: 54px;
 
   --height-padding: 20px;
   --min-width: 280px;
-  --min-height: 100px;
   --code-line: 24px;
   --dropdown-item: 30px;
 
@@ -39,6 +40,7 @@
   --outer-free-mode: var(--pc-height-outer-free-mode);
   --header: var(--pc-height-header);
   --item: var(--pc-item);
+  --min-height: var(--pc-min-height);
 
   --gray-8: #27272a;
   --gray-7: #23262f;
@@ -170,16 +172,19 @@
   overflow: auto;
   width: 100%;
   max-height: var(--inner);
+  min-height: var(--min-height);
   height: 100%;
 }
 
 .fg-editor.free-mode .wrapper-preview {
   max-height: var(--inner-free-mode);
+  min-height: calc(var(--header) + var(--min-height));
 }
 
 .fg-editor .code {
   display: block;
   padding: var(--height-padding) 10px;
+  min-height: var(--min-height);
   border-radius: 20px;
   font-size: 16px;
   color: var(--gray-6);
@@ -257,6 +262,7 @@
 .fg-editor .wrapper-code {
   overflow: auto;
   width: 100%;
+  min-height: var(--min-height);
 }
 
 .fg-editor .inner-code {
@@ -757,10 +763,6 @@
   .fg-editor .code {
     width: 100%;
   }
-
-  .fg-editor .wrapper-preview {
-    min-height: var(--mobile-height-outer);
-  }
 }
 
 @media screen and (max-width: 479px) {
@@ -771,6 +773,7 @@
     --outer-free-mode: var(--mobile-height-outer-free-mode);
     --header: var(--mobile-height-header);
     --item: var(--mobile-item);
+    --min-height: var(--mobile-min-height);
 
     align-items: center;
   }
@@ -788,14 +791,6 @@
 
   .fg-editor .preview {
     padding: var(--height-padding) 17px;
-  }
-
-  .fg-editor .wrapper-preview {
-    min-height: var(--min-height);
-  }
-
-  .fg-editor.free-mode .wrapper-preview {
-    min-height: var(--inner-free-mode);
   }
 
   .fg-editor .header-code .title {

--- a/utils/editor/editor.css
+++ b/utils/editor/editor.css
@@ -473,6 +473,10 @@
   vertical-align: text-top;
 }
 
+.fg-editor tr .button-add.button-inner {
+  margin: 0 5px;
+}
+
 .fg-editor tr .button-add:hover {
   background-color: var(--primary-5);
 }

--- a/utils/editor/editor.css
+++ b/utils/editor/editor.css
@@ -64,6 +64,10 @@
   --background: #ffffff;
   --box-shadow-2: #00000033;
   --box-shadow-1: #51459f14;
+  --add-button-color: var(--primary-5);
+  --add-button-background: var(--primary-2);
+  --remove-button-color: #878787;
+  --remove-button-background: #e0e0e0;
   --indicator: #efefef;
   --fixed-white: #ffffff;
   --fixed-gray-8: #27272a;
@@ -98,8 +102,12 @@
   --gray-1: #171718;
   --white: #23262f;
   --background: #3f3f46;
-  --box-shadow-2: #ffffff33;
+  --box-shadow-2: #ffffffaa;
   --box-shadow-1: #aeba6014;
+  --add-button-color: var(--primary-1);
+  --add-button-background: var(--primary-3);
+  --remove-button-color: #252424;
+  --remove-button-background: #878787;
   --indicator: #252424;
   --four-color-1: #f9b09e;
 }
@@ -630,22 +638,22 @@
 }
 
 .fg-editor .buttons .button:hover {
-  box-shadow: 0 0 2px 1px var(--box-shadow-2);
+  box-shadow: 0 0 2px 2px var(--box-shadow-2);
 }
 
 .fg-editor .buttons .button:active {
-  box-shadow: inset 0 0 2px 1px var(--box-shadow-2);
+  box-shadow: inset 0 0 2px 2px var(--box-shadow-2);
 }
 
 .fg-editor .buttons .button-add {
   margin-right: 12px;
-  background-color: var(--primary-2);
-  color: var(--primary-5);
+  background-color: var(--add-button-background);
+  color: var(--add-button-color);
 }
 
 .fg-editor .buttons .button-remove {
-  background-color: var(--gray-3);
-  color: var(--gray-5);
+  background-color: var(--remove-button-background);
+  color: var(--remove-button-color);
 }
 
 .fg-editor .wrapper-textarea {

--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -809,7 +809,7 @@
 
         const innerAddButton =
           textInput || isRootContainer || this._layout === 'carousel'
-            ? this._createAddInnerTagButton(line.tag)
+            ? this._createAddInnerTagButton(line.tag, 'button-inner')
             : null;
 
         const closingTag =
@@ -1078,12 +1078,15 @@
       return elem;
     }
 
-    _createAddInnerTagButton(tag) {
+    _createAddInnerTagButton(tag, className) {
       const elem = Tag.createElement(
         'button',
         { type: 'button', class: 'button-add' },
         '+'
       );
+      if (className) {
+        elem.classList.add(className);
+      }
 
       // HTML 코드가 하나도 없는 경우
       if (!tag) {

--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -172,7 +172,7 @@
   class Editor {
     // CSS 파싱을 위한 정규표현식
     static CSS_STRING =
-      /((\.((container\d*)|(item\d*)))+(:[\w\-]*)?(::[\w\-]*)?\s*)+\{[^{}]*\}/g;
+      /(?<selector>((\.((container\d*)|(item\d*)))+(\[[^:\{\}]*\])?(:[^:\{\}]*)?(::[^:\{\}]*)?\s*)+)(,\s*\k<selector>)*\{[^{}]*\}/g;
 
     // data-item을 입력하지 않았을 경우 기본값
     static DEFAULT_ITEM = 3;

--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -807,15 +807,17 @@
           });
         }
 
-        const innerAddButton =
-          textInput || isRootContainer || this._layout === 'carousel'
-            ? this._createAddInnerTagButton(line.tag, 'button-inner')
-            : null;
-
         const closingTag =
           !(typeof line.textContent === 'string') && line.className
             ? null
             : `</${tagName.toLowerCase()}>`;
+
+        const innerAddButton =
+          textInput ||
+          isRootContainer ||
+          (openingTag.length && closingTag && this._layout === 'carousel')
+            ? this._createAddInnerTagButton(line.tag, 'button-inner')
+            : null;
 
         const deleteButton = this._createDeleteTagButton(line.tag);
 

--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -1517,7 +1517,10 @@
         return;
       }
       const { anchorNode, focusNode, anchorOffset, focusOffset } = selection;
-      const selectedText = selection.toString().replace(/\n\d+(?=\n)/g, '');
+      const selectedText = selection
+        .toString()
+        .replace(/\n\d+(?=\n)/g, '')
+        .replaceAll('\u00A0', ' ');
 
       let anchorLine = anchorNode;
       let focusLine = focusNode;
@@ -1563,7 +1566,7 @@
         .reduce((acc, line) => acc + line.length + 1, 0);
 
       textarea.selectionStart = textarea.value
-        .replaceAll(' ', '\u00A0')
+        .replaceAll('\u00A0', ' ')
         .indexOf(selectedText, prevLength + startIndex);
       textarea.selectionEnd = textarea.selectionStart + selectedText.length;
     }

--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -322,7 +322,7 @@
           selector,
           ...props.map(({ prop, value }) => `${prop}:${value}`),
           '}',
-          '\u00A0'
+          ''
         );
       }
       if (this._mode === 'snippet') {
@@ -1204,10 +1204,18 @@
     _createStylesheet(styleText) {
       const stylesheet = styleText
         .replace(/\s+/g, ' ')
-        .replace(
-          Editor.CSS_STRING,
-          (match) => `.fg-editor.editor-${this._editorId} ${match}`
-        );
+        .replace(Editor.CSS_STRING, (match) => {
+          const index = match.indexOf('{');
+          const selectors = match.slice(0, index).split(', ');
+          const rest = match.slice(index);
+          return (
+            selectors
+              .map(
+                (selector) => `.fg-editor.editor-${this._editorId} ${selector}`
+              )
+              .join(', ') + rest
+          );
+        });
       return stylesheet;
     }
 

--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -1533,7 +1533,8 @@
       const selectedText = selection
         .toString()
         .replace(/\n\d+(?=\n)/g, '')
-        .replaceAll('\u00A0', ' ');
+        .replaceAll('\u00A0', ' ')
+        .replaceAll('}\n', '}\n\n');
 
       let anchorLine = anchorNode;
       let focusLine = focusNode;
@@ -1578,7 +1579,7 @@
         .slice(0, firstLine.dataset.index)
         .reduce((acc, line) => acc + line.length + 1, 0);
 
-      textarea.selectionStart = textarea.value
+      textarea.selectionStart = (textarea.value + '\n')
         .replaceAll('\u00A0', ' ')
         .indexOf(selectedText, prevLength + startIndex);
       textarea.selectionEnd = textarea.selectionStart + selectedText.length;

--- a/utils/editor/editor.js
+++ b/utils/editor/editor.js
@@ -1362,14 +1362,19 @@
           Editor.DROPDOWN_HEIGHT;
       }
       if (targetCode.classList.contains('value-code')) {
-        this._createValueDropdown(targetCode, selectorIndex, propIndex);
         const prop = this._curCss[selectorIndex].props[propIndex].prop;
+        if (prop.trim() === '') {
+          return;
+        }
+        this._createValueDropdown(targetCode, selectorIndex, propIndex);
         scrollTop =
           Editor.CSS_PROPS_INFO[prop].indexOf(targetCode.textContent) *
           Editor.DROPDOWN_HEIGHT;
       }
       targetCode.appendChild(this._dropdown);
-      this._dropdown.scrollTop = scrollTop;
+      if (this._dropdown) {
+        this._dropdown.scrollTop = scrollTop;
+      }
       this._isDropdownOpen = true;
     }
 


### PR DESCRIPTION
# 🐛 버그 수정
- carousel 모드에서 HTML 코드 추가 버튼(+)이 추가로 더 생기는 버그 수정
- 가상 클래스, 가상 요소, 특성 선택자 일부가 CSS에 반영되지 않는 버그 수정
- CSS 텍스트를 수정할 때 일부 텍스트의 선택 범위를 제대로 인지하지 못하는 버그 수정
- snippet 모드에서 CSS 속성을 선택하기 전에 먼저 CSS 속성 값을 설정하려고 할 때 에러가 발생하는 버그 수정
- CSS 그룹 선택자(,)가 있는 경우 문서 전체의 스타일에 영향을 주는 버그 수정

# 💄 UI 변경
- Add Item, Remove Item 버튼 수정
- snippet 모드의 CSS 코드를 선택 불가능하도록 변경
- 에디터 전체의 min-height 설정
- HTML container 코드 내부의 코드 추가 버튼(+)의 margin 변경
- CSS 코드의 빈 줄에 있는 공백 문자 제거