### PR TITLE
검색 페이지 마크업 수정 및 검색 기능 보완

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -30,8 +30,8 @@
         </ul>
         <ul class="nav-right">
           <li class="search">
-            <form action="/search" method="get">
-              <input type="text" class="search-input" placeholder="Search" />
+            <form action="" method="get" autocomplete="off">
+              <input type="text" class="search-input" name="q" placeholder="Search" />
               <button type="submit" class="search-btn">
                 <span class="a11y-hidden">검색버튼</span>
               </button>

--- a/search/index.html
+++ b/search/index.html
@@ -19,7 +19,7 @@
       <nav>
         <ul class="nav-left">
           <li>
-            <a href="#" class="header-logo">
+            <a href="/" class="header-logo">
               <span class="a11y-hidden">로고</span>
             </a>
           </li>
@@ -30,10 +30,12 @@
         </ul>
         <ul class="nav-right">
           <li class="search">
-            <input type="text" class="search-input" placeholder="Search" />
-            <button class="search-btn">
-              <span class="a11y-hidden">검색버튼</span>
-            </button>
+            <form action="/search" method="get">
+              <input type="text" class="search-input" placeholder="Search" />
+              <button type="submit" class="search-btn">
+                <span class="a11y-hidden">검색버튼</span>
+              </button>
+            </form>
             <div class="modal-history">
               <div class="header-history">
                 <strong class="tit-history">최근 검색어</strong>

--- a/search/index.html
+++ b/search/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>search</title>
     <link rel="stylesheet" href="../src/css/default.css" />
+    <link rel="stylesheet" href="../../src/css/color.css">
     <link rel="stylesheet" href="./style.css" />
     <!-- <link rel="stylesheet" href="../src/components/gnb-nav.css" /> -->
     <link rel="stylesheet" href="../src/components/search-item.css" />
@@ -14,7 +15,7 @@
   </head>
   <body>
     <h1 class="sr-only">검색 페이지입니다.</h1>
-    <header class="header">
+    <header class="gnb-header">
       <nav>
         <ul class="nav-left">
           <li>
@@ -42,12 +43,12 @@
             </div>
           </li>
           <li>
-            <button class="darkmode">
+            <button class="darkmode-btn">
               <span class="a11y-hidden">다크 모드 버튼</span>
             </button>
           </li>
           <li>
-            <button class="github">
+            <button class="github-btn">
               <span class="a11y-hidden">깃헙 바로가기 버튼</span>
             </button>
           </li>

--- a/search/search.js
+++ b/search/search.js
@@ -27,8 +27,11 @@ const searchItem = document.querySelectorAll(".itemwrap-search");
 const searchText = document.querySelector(".text-search");
 const searchResultCount = document.querySelector(".text-search-count");
 
+const URLSearch = new URLSearchParams(location.search);
+const searchQuery = URLSearch.get('q');
+
 //검색한 텍스트 표시
-searchText.innerText = `Results for "${localStorage.getItem("search")}"`;
+searchText.innerText = `Results for "${searchQuery}"`;
 //아이템 갯수 표시
 searchResultCount.innerText = `Showing ${searchItem.length} results`;
 
@@ -54,6 +57,7 @@ document.addEventListener("click", (e) => {
 
   //모달에 있는 X버튼 터치 시 해당 아이템 삭제
   if (e.target.classList.value == "btn-del") {
+    e.preventDefault(); 
     const inText = e.target.previousSibling.innerText;
     searchHistory = searchHistory.filter((text) => {
       return text !== inText;
@@ -98,6 +102,7 @@ const createHistory = () => {
       const deleteImage = document.createElement("img");
 
       listItem.setAttribute("class", "list-item");
+      listItem.setAttribute("href", `/search/?q=${v}`);
       serachText.setAttribute("class", "txt-item");
       deleteBtn.setAttribute("class", "btn-del");
       deleteImage.setAttribute("src", "../src/assets/images/icon-close.svg");

--- a/search/style.css
+++ b/search/style.css
@@ -33,7 +33,13 @@
   color: #878787;
 }
 
-/* 헤더css 일시적으로 가져왔습니다. */
+/* 모달 엑스버튼 이미지 안눌리게 */
+.close-img {
+  pointer-events: none;
+}
+
+
+/* 헤더css 일시적으로 가져왔습니다. => 재사용성 고려해 selector 수정해보았습니다. */
 
 /* .a11y-hidden : 웹접근성 위해 - 텍스트는 눈에 보이지 않지만 스크린 리더기가 읽을 수 있음 */
 .a11y-hidden {
@@ -53,7 +59,7 @@
   margin: 0;
 }
 
-header {
+.gnb-header {
   width: 100%;
   height: 80px;
   padding: 0 160px;
@@ -61,7 +67,7 @@ header {
   color: var(--secondary);
 }
 
-nav {
+.gnb-header nav {
   width: 100%;
   height: 100%;
   display: flex;
@@ -69,49 +75,51 @@ nav {
   font-size: 18px;
 }
 
-.header-logo {
+.gnb-header .header-logo {
   display: inline-block;
   width: 144px;
   height: 20px;
   background: url(/src/assets/images/logo.svg) no-repeat;
 }
 
-ul.nav-left {
+.gnb-header ul.nav-left {
   display: flex;
   box-sizing: border-box;
 }
 
-nav ul.nav-left li a {
+.gnb-header nav ul.nav-left li a {
   line-height: 28px;
 }
 
-ul.nav-left li {
+.gnb-header ul.nav-left li {
   display: flex;
   align-items: center;
 }
 
-ul.nav-left li {
+.gnb-header ul.nav-left li {
   margin-right: 30px;
   padding: 26px 0;
 }
 
-ul.nav-left li:last-child {
+.gnb-header ul.nav-left li:last-child {
   margin-right: 0;
 }
-ul.nav-left li:first-child {
+
+.gnb-header ul.nav-left li:first-child {
   margin-right: 32px;
   padding: 30px 0;
 }
 
-nav ul.nav-right {
+.gnb-header nav ul.nav-right {
   display: flex;
   box-sizing: border-box;
   padding: 20px 0;
 }
 
-.search {
+.gnb-header .search {
   position: relative;
 }
+
 .search-input {
   width: 265px;
   height: 40px;
@@ -132,7 +140,7 @@ nav ul.nav-right {
   font-size: 1;
 }
 
-.darkmode {
+.darkmode-btn {
   width: 37px;
   height: 37px;
   display: flex;
@@ -144,7 +152,7 @@ nav ul.nav-right {
   font-size: 1;
 }
 
-.github {
+.github-btn {
   width: 37px;
   height: 37px;
   display: flex;
@@ -157,43 +165,32 @@ nav ul.nav-right {
 }
 
 /* 다크모드 */
+/* header에만 on 클래스를 붙이면 다크모드로 전환되도록 수정했습니다. */
+.gnb-header.on {
+  background-color: var(--primary);
+  color: var(--background);
+}
 
-.header-logo.on {
+.gnb-header.on .header-logo {
   display: inline-block;
   width: 144px;
   height: 20px;
   background: url(/src/assets/images/logo-darkmode.svg) no-repeat;
 }
 
-.header.on {
-  background-color: var(--primary);
+.gnb-header.on nav li {
   color: var(--background);
 }
 
-nav li.on {
-  color: var(--background);
-}
-
-.search.on {
-  background-color: var(--black);
-  color: var(--secondary);
-  border: 1px solid var(--secondary);
-}
-
-.search-input.on {
+.gnb-header.on .search-input {
   background-color: var(--black);
   border: none;
 }
 
-.darkmode.on {
+.gnb-header.on .darkmode-btn {
   background: url(/src/assets/images/icon-moon-dark.svg) center no-repeat;
 }
 
-.github.on {
+.gnb-header.on .github-btn {
   background: url(/src/assets/images/icon-github-dark.svg) center no-repeat;
-}
-
-/* 모달 엑스버튼 이미지 안눌리게 */
-.close-img {
-  pointer-events: none;
 }


### PR DESCRIPTION
- 헤더 컴포넌트의 재사용성을 고려해 기존 CSS에서 태그 셀렉터가 부모 클래스를 타고 들어가게 수정
- header 태그의 클래스에 on을 붙여 다크모드 동작하도록 CSS 수정
- 헤더 컴포넌트의 클래스 이름 충돌을 방지하기 위해 일부 수정
- 검색 아이콘 클릭 시 검색 -> 엔터로도 검색할 수 있게 마크업에 get 방식 form 추가하고 버튼 submit 타입 명시
- 최근 검색어 아이템에 url 쿼리스트링으로 href 속성 부여해 링크 추가