### PR TITLE
에디터 css 수정

### DIFF
--- a/src/utils/editor/editor.css
+++ b/src/utils/editor/editor.css
@@ -878,6 +878,11 @@
     right: 65px;
   }
 
+  .fg-editor .item.stressed,
+  .fg-editor .container.stressed {
+    outline: 2px solid var(--primary-3) !important;
+  }
+
   .fg-editor.carousel-layout .code,
   .fg-editor.carousel-layout .container-indicators {
     display: none;

--- a/src/utils/editor/editor.css
+++ b/src/utils/editor/editor.css
@@ -175,6 +175,7 @@
   overflow: hidden;
   width: calc(50% - 10px);
   max-height: var(--outer);
+  background-color: var(--white);
   box-shadow: 0px 4px 12px 0px var(--box-shadow-1);
 }
 
@@ -187,6 +188,10 @@
 .fg-editor .preview {
   padding: var(--height-padding) 30px;
   border-radius: 20px;
+}
+
+.fg-editor.carousel-layout .preview {
+  background-color: transparent;
 }
 
 .fg-editor .wrapper-preview {
@@ -208,7 +213,6 @@
   padding: var(--height-padding) 10px;
   min-height: var(--min-height);
   border-radius: 20px;
-  background-color: var(--white);
   font-size: 16px;
   color: var(--gray-6);
 }

--- a/src/utils/editor/editor.css
+++ b/src/utils/editor/editor.css
@@ -832,7 +832,7 @@
   }
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 479px) {
   .fg-editor {
     --inner: var(--mobile-height-inner);
     --inner-free-mode: var(--mobile-height-inner-free-mode);


### PR DESCRIPTION
- 모바일 브레이크 포인트를 480px로 변경
- 에디터의 preview에 배경색을 추가하여 다크모드일 때 배경색이 보이도록 함. 그리고 carousel 모드에서는 여전히 배경색이 없도록 함
- 모바일에서 html 코드를 선택할 때 해당 tag의 DOM에 생기는 outline의 두께를 2px로 변경