### PR TITLE
safari 호환을 위해 후방탐색 정규표현식 수정

### DIFF
--- a/search/searchPage.js
+++ b/search/searchPage.js
@@ -27,22 +27,22 @@ const contents = [];
 
   const codeBlockStart = {
     regex: /^\s*`{3}(.+)/,
-    replace: '<pre><code>$1',
+    replace: '<pre><code>$1'
   };
 
   const codeBlockEnd = {
     regex: /(.*)`{3}\s*$/,
-    replace: '$1</code></pre>',
+    replace: '$1</code></pre>'
   };
 
   const unorderedListItem = {
     regex: /^\s*-\s(.+)/,
-    replace: '<li>$1',
+    replace: '<li>$1'
   };
 
   const orderedListItem = {
     regex: /^\s*(\d+\.\s.+)/,
-    replace: '<li>$1',
+    replace: '<li>$1'
   };
 
   const tableRow = {
@@ -53,12 +53,12 @@ const contents = [];
         .map((text) => `<td>${text.trim()}</td>`)
         .join('');
       return `<tr>${heads}</tr>`;
-    },
+    }
   };
 
   const tableDivision = {
     regex: /^\|(([-|]|\s)+)\|$/,
-    replace: '',
+    replace: ''
   };
 
   const heading = {
@@ -69,7 +69,7 @@ const contents = [];
         /(\*{2})|`/g,
         ''
       )}">${group}</${tagName}>`;
-    },
+    }
   };
 
   const figure = {
@@ -81,36 +81,36 @@ const contents = [];
       }/src/pages/${PAGE_NAME}/${g2}"${
         width ? ` style="width: ${width}px;"` : ''
       }>${g1 ? `<figcaption>${g1}</figcaption>` : ''}</figure>`;
-    },
+    }
   };
 
   const lineBreak = {
     regex: /^<br\s*\/>$/,
-    replace: '<br />',
+    replace: '<br />'
   };
 
   const paragraph = {
-    regex: /(?<=^|\n)(.+)$/,
+    regex: /(?:^|\n)(.+)$/,
     tagName: 'p',
-    replace: (matched) =>
+    replace: (matched, group) =>
       /\<(\/)?(h\d|ul|ol|li|blockquote|pre|img|code)/.test(matched)
         ? matched
-        : '<p>' + matched + '</p>',
+        : '<p>' + group + '</p>'
   };
 
   const link = {
     regex: /\[(.+)\]\((.+)\)/g,
-    replace: '<a href="$2">$1</a>',
+    replace: '<a href="$2">$1</a>'
   };
 
   const strong = {
     regex: /\*{2}(([^*])+)\*{2}/g,
-    tagName: 'strong',
+    tagName: 'strong'
   };
 
   const code = {
     regex: /`([^`]+)`/g,
-    tagName: 'code',
+    tagName: 'code'
   };
 
   const listDepth = (token) => {
@@ -126,7 +126,7 @@ const contents = [];
     tableRow,
     heading,
     figure,
-    lineBreak,
+    lineBreak
   ];
 
   const inlineRules = [link, strong, code];

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -77,12 +77,12 @@
   };
 
   const paragraph = {
-    regex: /(?<=^|\n)(.+)$/,
+    regex: /(?:^|\n)(.+)$/,
     tagName: 'p',
-    replace: (matched) =>
+    replace: (matched, group) =>
       /\<(\/)?(h\d|ul|ol|li|blockquote|pre|img|code)/.test(matched)
         ? matched
-        : '<p>' + matched + '</p>'
+        : '<p>' + group + '</p>'
   };
 
   const link = {

--- a/src/utils/editor/editor.js
+++ b/src/utils/editor/editor.js
@@ -2022,7 +2022,8 @@
             .map((selector) => selector.trim());
           const rest = match
             .slice(index)
-            .replace(/((?<=[{}:;])\s+)|(\s+(?=[{}:;]))/g, '');
+            .replace(/([{}:;])(\s+)/g, '$1')
+            .replace(/(\s+)(?=[{}:;])/g, '');
           return (
             selectors
               .map(


### PR DESCRIPTION
safari 호환을 위해 후방탐색(?<=) 정규표현식을 다른 정규표현식으로 대체하였습니다.